### PR TITLE
Heading correction

### DIFF
--- a/.github/scripts/constants.py
+++ b/.github/scripts/constants.py
@@ -13,7 +13,7 @@ excused_dirs = [
 ]
 
 # Weird stuff that shouldn't go in constants, dont put function/var names in here theyre already checked
-excused_cases = ["ModuleIOSparkMax", "case", "new Module(", "new BaseStatusSignal[", "BaseStatusSignal.waitForAll(", "new ModuleIOHybrid(", "Math.pow("]
+excused_cases = ["ModuleIOSparkMax", "case", "new Module(", "new BaseStatusSignal[", "BaseStatusSignal.waitForAll(", "new ModuleIOHybrid(", "Math.pow(", "(applyHeadingCorrection ? rotationMultiplier : 1)"]
 
 def check_for_magic_numbers(file_path):
     magic_numbers = []

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -179,6 +179,9 @@ public final class Constants {
 
 	public static final class Drive {
 
+		// TODO: Test and tune!
+		public static final PIDConstants HEADING_CORRECTION_PID = new PIDConstants(1, 0, 0);
+
 		public static final double DISCRETIZE_TIME_SECONDS = 0.02;
 		public static final double CONTROLLER_DEADBAND = 0.1;
 		public static final int NUM_MODULES = 4;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -220,6 +220,7 @@ public final class Constants {
 		}
 
 		public static final class Navx2 {
+
 			public static final double UPDATE_FREQUENCY = 1000.0;
 		}
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -269,26 +269,33 @@ public final class Constants {
 				public static final int SPARK_AVG_DEPTH = 2;
 				public static final double SPARK_FRAME_PERIOD = 1000.0 / ODOMETRY_FREQUENCY;
 
-				// CAN/Device IDS and offsets
-				public static final int DRIVE0_ID = 0;
-				public static final int TURN0_ID = 1;
-				public static final int CANCODER0_ID = 2;
-				public static final double OFFSET0 = 0.0;
+				// CAN/Device IDS and offsets (May be Wrong, guessed which ids are correct off vibes)
 
-				public static final int DRIVE1_ID = 0;
+				// TODO: Confirm module IDs are associated with correct module and tune module offsets if last years dont work
+
+				// Front Left Module
+				public static final int DRIVE0_ID = 8;
+				public static final int TURN0_ID = 7;
+				public static final int CANCODER0_ID = 9;
+				public static final double OFFSET0 = 290.0;
+ 
+				// Front Right Module
+				public static final int DRIVE1_ID = 2;
 				public static final int TURN1_ID = 1;
-				public static final int CANCODER1_ID = 2;
-				public static final double OFFSET1 = 0.0;
+				public static final int CANCODER1_ID = 3;
+				public static final double OFFSET1 = 170.0;
 
-				public static final int DRIVE2_ID = 0;
-				public static final int TURN2_ID = 1;
-				public static final int CANCODER2_ID = 2;
-				public static final double OFFSET2 = 0.0;
+				// Back Left Module
+				public static final int DRIVE2_ID = 5;
+				public static final int TURN2_ID = 4;
+				public static final int CANCODER2_ID = 6;
+				public static final double OFFSET2 = 342.2;
 
-				public static final int DRIVE3_ID = 0;
-				public static final int TURN3_ID = 1;
-				public static final int CANCODER3_ID = 2;
-				public static final double OFFSET3 = 0.0;
+				// Back Right Module
+				public static final int DRIVE3_ID = 11;
+				public static final int TURN3_ID = 10;
+				public static final int CANCODER3_ID = 12;
+				public static final double OFFSET3 = 220.5;
 			}
 		}
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -219,6 +219,10 @@ public final class Constants {
 			public static final double UPDATE_FREQUENCY = 100.0;
 		}
 
+		public static final class Navx2 {
+			public static final double UPDATE_FREQUENCY = 1000.0;
+		}
+
 		public static final class Module {
 
 			public static final double ODOMETRY_FREQUENCY = 250.0;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -223,7 +223,6 @@ public final class Constants {
 
 			public static final double ODOMETRY_FREQUENCY = 250.0;
 
-			// There isnt one for real its just all 0 so idk whats good with that
 			public static final FFConstants REPLAY_FF = new FFConstants(0.1, 0.13);
 			public static final PIDConstants REPLAY_DRIVE_PID = new PIDConstants(0.05, 0.0, 0.0);
 			public static final PIDConstants REPLAY_TURN_PID = new PIDConstants(7.0, 0.0, 0.0);
@@ -231,6 +230,11 @@ public final class Constants {
 			public static final FFConstants SIM_FF = new FFConstants(0.0, 0.13);
 			public static final PIDConstants SIM_DRIVE_PID = new PIDConstants(0.1, 0.0, 0.0);
 			public static final PIDConstants SIM_TURN_PID = new PIDConstants(10.0, 0.0, 0.0);
+
+			// Hope this works??? This should be tuned using SYSID or Power, I, and Damping method
+			public static final FFConstants REAL_FF = new FFConstants(0, 0);
+			public static final PIDConstants REAL_DRIVE_PID = new PIDConstants(0.05, 0.0, 0.0);
+			public static final PIDConstants REAL_TURN_PID = new PIDConstants(7.0, 0.0, 0.0);
 
 			public static final int NUM_TURN_MOTORS = 1;
 			public static final int NUM_DRIVE_MOTORS = 1;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -282,7 +282,7 @@ public final class Constants {
 				public static final int TURN0_ID = 7;
 				public static final int CANCODER0_ID = 9;
 				public static final double OFFSET0 = 290.0;
- 
+
 				// Front Right Module
 				public static final int DRIVE1_ID = 2;
 				public static final int TURN1_ID = 1;

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -27,10 +27,10 @@ import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import frc.robot.Constants;
 import frc.robot.subsystems.Subsystem;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;import frc.robot.Constants;
-
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.DoubleSupplier;
 import org.littletonrobotics.junction.AutoLogOutput;
 import org.littletonrobotics.junction.Logger;
@@ -79,7 +79,11 @@ public class Drive extends Subsystem<DriveStates> {
 		modules[3] = new Module(brModuleIO, 3);
 
 		cachedTargetRotation = gyroInputs.yawPosition.getRadians();
-		headingCorrectionController = new PIDController(Constants.Drive.HEADING_CORRECTION_PID.kP, Constants.Drive.HEADING_CORRECTION_PID.kI , Constants.Drive.HEADING_CORRECTION_PID.kD);
+		headingCorrectionController = new PIDController(
+			Constants.Drive.HEADING_CORRECTION_PID.kP,
+			Constants.Drive.HEADING_CORRECTION_PID.kI,
+			Constants.Drive.HEADING_CORRECTION_PID.kD
+		);
 		// Start threads (no-op for each if no signals have been created)
 		PhoenixOdometryThread.getInstance().start();
 		SparkMaxOdometryThread.getInstance().start();
@@ -148,10 +152,13 @@ public class Drive extends Subsystem<DriveStates> {
 			omegaSupplier.getAsDouble(),
 			Constants.Drive.CONTROLLER_DEADBAND
 		);
-		boolean applyHeadingCorrection = headingCorrection & omega == 0;
+		boolean applyHeadingCorrection = headingCorrection & (omega == 0);
 
 		if (applyHeadingCorrection) {
-			omega = headingCorrectionController.calculate(gyroInputs.yawPosition.getRadians(), cachedTargetRotation);
+			omega = headingCorrectionController.calculate(
+				gyroInputs.yawPosition.getRadians(),
+				cachedTargetRotation
+			);
 		} else {
 			// Like stored the good rotation?? idk
 			cachedTargetRotation = gyroInputs.yawPosition.getRadians();
@@ -160,8 +167,6 @@ public class Drive extends Subsystem<DriveStates> {
 			linearMagnitude = linearMagnitude * linearMagnitude;
 			omega = Math.copySign(omega * omega, omega);
 		}
-
-		
 
 		// Calcaulate new linear velocity
 		Translation2d linearVelocity = new Pose2d(new Translation2d(), linearDirection)
@@ -180,7 +185,9 @@ public class Drive extends Subsystem<DriveStates> {
 				linearVelocity.getY() *
 				drive.getMaxLinearSpeedMetersPerSec() *
 				translationMultiplier,
-				omega * drive.getMaxAngularSpeedRadPerSec() * (applyHeadingCorrection ? rotationMultiplier : 1),
+				omega *
+				drive.getMaxAngularSpeedRadPerSec() *
+				(applyHeadingCorrection ? rotationMultiplier : 1),
 				isFlipped ? drive.getRotation().plus(new Rotation2d(Math.PI)) : drive.getRotation()
 			)
 		);

--- a/src/main/java/frc/robot/subsystems/drive/GyroIONavx2.java
+++ b/src/main/java/frc/robot/subsystems/drive/GyroIONavx2.java
@@ -4,6 +4,8 @@ import com.kauailabs.navx.frc.AHRS;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.SPI;
+import frc.robot.Constants;
+
 import java.util.LinkedList;
 import java.util.Queue;
 
@@ -24,7 +26,7 @@ public class GyroIONavx2 implements GyroIO {
 		inputs.yawPosition = Rotation2d.fromDegrees(navx.getYaw());
 		inputs.yawVelocityRadPerSec = Units.degreesToRadians(navx.getRate());
 
-		yawTimestampQueue.add((double) System.currentTimeMillis() / 1000.0); // Time in seconds
+		yawTimestampQueue.add((double) System.currentTimeMillis() / Constants.Drive.Navx2.UPDATE_FREQUENCY); // Time in seconds
 		yawPositionQueue.add((double) navx.getYaw());
 
 		inputs.odometryYawTimestamps = yawTimestampQueue

--- a/src/main/java/frc/robot/subsystems/drive/GyroIONavx2.java
+++ b/src/main/java/frc/robot/subsystems/drive/GyroIONavx2.java
@@ -5,7 +5,6 @@ import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.SPI;
 import frc.robot.Constants;
-
 import java.util.LinkedList;
 import java.util.Queue;
 
@@ -26,7 +25,9 @@ public class GyroIONavx2 implements GyroIO {
 		inputs.yawPosition = Rotation2d.fromDegrees(navx.getYaw());
 		inputs.yawVelocityRadPerSec = Units.degreesToRadians(navx.getRate());
 
-		yawTimestampQueue.add((double) System.currentTimeMillis() / Constants.Drive.Navx2.UPDATE_FREQUENCY); // Time in seconds
+		yawTimestampQueue.add(
+			(double) System.currentTimeMillis() / Constants.Drive.Navx2.UPDATE_FREQUENCY
+		); // Time in seconds
 		yawPositionQueue.add((double) navx.getYaw());
 
 		inputs.odometryYawTimestamps = yawTimestampQueue

--- a/src/main/java/frc/robot/subsystems/drive/GyroIONavx2.java
+++ b/src/main/java/frc/robot/subsystems/drive/GyroIONavx2.java
@@ -1,0 +1,41 @@
+package frc.robot.subsystems.drive;
+
+import com.kauailabs.navx.frc.AHRS;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.SPI;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class GyroIONavx2 implements GyroIO {
+
+	// I forgot what we plugged the NavX into :(
+	private final AHRS navx;
+	private final Queue<Double> yawPositionQueue = new LinkedList<>();
+	private final Queue<Double> yawTimestampQueue = new LinkedList<>();
+
+	public GyroIONavx2(SPI.Port port) {
+		navx = new AHRS(port);
+		navx.reset();
+	}
+
+	public void updateInputs(GyroIOInputs inputs) {
+		inputs.connected = navx.isConnected();
+		inputs.yawPosition = Rotation2d.fromDegrees(navx.getYaw());
+		inputs.yawVelocityRadPerSec = Units.degreesToRadians(navx.getRate());
+
+		yawTimestampQueue.add((double) System.currentTimeMillis() / 1000.0); // Time in seconds
+		yawPositionQueue.add((double) navx.getYaw());
+
+		inputs.odometryYawTimestamps = yawTimestampQueue
+			.stream()
+			.mapToDouble(Double::doubleValue)
+			.toArray();
+		inputs.odometryYawPositions = yawPositionQueue
+			.stream()
+			.map(Rotation2d::fromDegrees)
+			.toArray(Rotation2d[]::new);
+		yawTimestampQueue.clear();
+		yawPositionQueue.clear();
+	}
+}

--- a/src/main/java/frc/robot/subsystems/drive/Module.java
+++ b/src/main/java/frc/robot/subsystems/drive/Module.java
@@ -45,7 +45,7 @@ public class Module {
 		// Switch constants based on mode (the physics simulator is treated as a
 		// separate robot with different tuning)
 		switch (Constants.currentMode) {
-			// TODO: Configure PID in rela mabye? idk why its off
+			// TODO: Configure PID in real mabye? idk why its off
 			case REAL:
 			case REPLAY:
 				driveFeedforward = new SimpleMotorFeedforward(

--- a/src/main/java/frc/robot/subsystems/drive/Module.java
+++ b/src/main/java/frc/robot/subsystems/drive/Module.java
@@ -45,8 +45,23 @@ public class Module {
 		// Switch constants based on mode (the physics simulator is treated as a
 		// separate robot with different tuning)
 		switch (Constants.currentMode) {
-			// TODO: Configure PID in real mabye? idk why its off
+			// TODO: Leaving this as a warning incase I did something bad, before "REAL" didnt assign any PID/FF values for controllers idk why
 			case REAL:
+				driveFeedforward = new SimpleMotorFeedforward(
+					Constants.Drive.Module.REAL_FF.kS,
+					Constants.Drive.Module.REAL_FF.kV
+				);
+				driveFeedback = new PIDController(
+					Constants.Drive.Module.REAL_DRIVE_PID.kP,
+					Constants.Drive.Module.REAL_DRIVE_PID.kI,
+					Constants.Drive.Module.REAL_DRIVE_PID.kD
+				);
+				turnFeedback = new PIDController(
+					Constants.Drive.Module.REAL_TURN_PID.kP,
+					Constants.Drive.Module.REAL_TURN_PID.kI,
+					Constants.Drive.Module.REAL_TURN_PID.kD
+				);
+				break;
 			case REPLAY:
 				driveFeedforward = new SimpleMotorFeedforward(
 					Constants.Drive.Module.REPLAY_FF.kS,

--- a/src/main/java/frc/robot/subsystems/manager/Manager.java
+++ b/src/main/java/frc/robot/subsystems/manager/Manager.java
@@ -1,12 +1,13 @@
 package frc.robot.subsystems.manager;
 
+import edu.wpi.first.wpilibj.SPI;
 import frc.robot.Constants;
 import frc.robot.subsystems.*;
 import frc.robot.subsystems.ampBar.*;
 import frc.robot.subsystems.drive.AutoAlign;
 import frc.robot.subsystems.drive.Drive;
 import frc.robot.subsystems.drive.GyroIO;
-import frc.robot.subsystems.drive.GyroIOPigeon2;
+import frc.robot.subsystems.drive.GyroIONavx2;
 import frc.robot.subsystems.drive.ModuleIO;
 import frc.robot.subsystems.drive.ModuleIOHybrid;
 import frc.robot.subsystems.drive.ModuleIOSim;
@@ -31,7 +32,7 @@ public class Manager extends Subsystem<ManagerStates> {
 				ampBarSubsystem = new AmpBar(new AmpBarIOReal());
 				shooterSubsystem = new Shooter(new ShooterIOTalonFX());
 				driveSubsystem = new Drive(
-					new GyroIOPigeon2(false),
+					new GyroIONavx2(SPI.Port.kMXP),
 					new ModuleIOHybrid(0),
 					new ModuleIOHybrid(1),
 					new ModuleIOHybrid(2),

--- a/vendordeps/NavX.json
+++ b/vendordeps/NavX.json
@@ -1,0 +1,40 @@
+{
+    "fileName": "NavX.json",
+    "name": "NavX",
+    "version": "2024.1.0",
+    "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
+    "frcYear": "2024",
+    "mavenUrls": [
+        "https://dev.studica.com/maven/release/2024/"
+    ],
+    "jsonUrl": "https://dev.studica.com/releases/2024/NavX.json",
+    "javaDependencies": [
+        {
+            "groupId": "com.kauailabs.navx.frc",
+            "artifactId": "navx-frc-java",
+            "version": "2024.1.0"
+        }
+    ],
+    "jniDependencies": [],
+    "cppDependencies": [
+        {
+            "groupId": "com.kauailabs.navx.frc",
+            "artifactId": "navx-frc-cpp",
+            "version": "2024.1.0",
+            "headerClassifier": "headers",
+            "sourcesClassifier": "sources",
+            "sharedLibrary": false,
+            "libName": "navx_frc",
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "linuxathena",
+                "linuxraspbian",
+                "linuxarm32",
+                "linuxarm64",
+                "linuxx86-64",
+                "osxuniversal",
+                "windowsx86-64"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adds heading correction, so when the drive train "Drifts" because of unaligned modules or hardware errors, the robot will automatically correct its rotation. Idk if this is the right way to do this and idk if it works but its wtv